### PR TITLE
AsyncIOScheduler shutdown and wakeup fix

### DIFF
--- a/apscheduler_di/decorator.py
+++ b/apscheduler_di/decorator.py
@@ -99,13 +99,9 @@ class ContextSchedulerDecorator(BaseScheduler):
         super().__init__()
 
     def wakeup(self) -> None:
-        if isinstance(self._scheduler, AsyncIOScheduler):
-            return run_in_event_loop(self._scheduler.wakeup)()
         self._scheduler.wakeup()
 
     def shutdown(self, wait: bool = True) -> None:
-        if isinstance(self._scheduler, AsyncIOScheduler):
-            return run_in_event_loop(self._scheduler.shutdown)()
         self._scheduler.shutdown(wait=wait)
 
     def add_job(


### PR DESCRIPTION
Removed unnecessary code, because methods `shutdown` and `wakeup` of class `AsyncIOScheduler` are covered by `@run_in_event_loop` decorator by itself.
Existing code causes this error on shutdown event when stopping runtime by hitting Ctrl+C (`KeyboardInterrupt`):

`TypeError: AsyncIOScheduler.shutdown() missing 1 required positional argument: 'self'`

By this fix this error no more occures.

MRE:
```
import asyncio
import datetime

from apscheduler.schedulers.asyncio import AsyncIOScheduler
from apscheduler.triggers.date import DateTrigger
from apscheduler_di import ContextSchedulerDecorator


async def job():
    counter = 0
    while True:
        print(f'Counter: {counter}')
        counter += 1
        await asyncio.sleep(1)


async def main():
    scheduler = ContextSchedulerDecorator(AsyncIOScheduler())

    scheduler.add_job(job, DateTrigger(datetime.datetime.now() + datetime.timedelta(seconds=10)))
    scheduler.start()
    try:
        await asyncio.Future()
    finally:
        scheduler.shutdown(wait=True)


if __name__ == '__main__':
    asyncio.run(main())
```